### PR TITLE
Keep domains and identities during upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,7 +22,7 @@ fi
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir/app" --full_replace --keep="data/_data_/_default_/configs/application.ini"
+ynh_setup_source --dest_dir="$install_dir/app" --full_replace --keep="data/_data_/_default_"
 
 #=================================================
 # UPDATE A CONFIG FILE


### PR DESCRIPTION
## Problem

- *After upgrades, some configs are lots*
- domains added as an admin
- user identities
- user signatures

## Solution

- *Keep the whole directory storing the app settings during upgrade*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
